### PR TITLE
Fix None `node_heading` in Node body

### DIFF
--- a/orgroamtools/data.py
+++ b/orgroamtools/data.py
@@ -59,7 +59,7 @@ class RoamNode:
             Body text of node
         """
         root = op.load(self.fname)
-        node_heading = None
+        node_heading = [] 
         for node in root:
             if node.get_property("ID") == self.id:
                 node_heading = node


### PR DESCRIPTION
I had a problem in RoamNode's `body` property when there were no submodes (the `node_heading` was None so it was not iterable). That fixes it.